### PR TITLE
Use matchPhrasePrefix query for much more sensible region search results

### DIFF
--- a/src/main/scala/au/csiro/data61/magda/search/elasticsearch/ElasticSearchQueryer.scala
+++ b/src/main/scala/au/csiro/data61/magda/search/elasticsearch/ElasticSearchQueryer.scala
@@ -312,7 +312,7 @@ class ElasticSearchQueryer(implicit val system: ActorSystem, implicit val ec: Ex
 
   override def searchRegions(query: String, start: Long, limit: Int): Future[RegionSearchResult] = {
     clientFuture.flatMap { client =>
-      client.execute(ElasticDsl.search in "regions" / "regions" query (query + "*") start start.toInt limit limit sourceExclude("geometry"))
+      client.execute(ElasticDsl.search in "regions" / "regions" query { matchPhrasePrefixQuery("name", query) } start start.toInt limit limit sourceExclude("geometry"))
         .flatMap { response =>
           response.totalHits match {
             case 0 => Future(RegionSearchResult(query, 0, List())) // If there's no hits, no need to do anything more


### PR DESCRIPTION
The order still isn't ideal, but at least the results actually make sense now.